### PR TITLE
Issue #23: Only unset deletemodules during unit tests

### DIFF
--- a/classes/delete_task.php
+++ b/classes/delete_task.php
@@ -60,13 +60,15 @@ class delete_task {
      * @return array
      */
     public function get_deletemodules() {
-        // Unset if the module is already deleted successfully.
-        // This is only required if MDL-80930 is not applied.
-        // MDL-80930 is integrated, there should be no "NULL moduleinstanceid".
-        foreach ($this->deletemodules as $key => $deletemodule) {
-            // No instanceid.
-            if (is_null($deletemodule->moduleinstanceid)) {
-                unset($this->deletemodules[$key]);
+        if (defined('PHPUNIT_TEST') && PHPUNIT_TEST) {
+            // Unset if the module is already deleted successfully.
+            // This is only required if MDL-80930 is not applied.
+            // MDL-80930 is integrated, there should be no "NULL moduleinstanceid".
+            foreach ($this->deletemodules as $key => $deletemodule) {
+                // No instanceid.
+                if (is_null($deletemodule->moduleinstanceid)) {
+                    unset($this->deletemodules[$key]);
+                }
             }
         }
         return $this->deletemodules;


### PR DESCRIPTION
**Description:** Sites show the error in Issue #23 in the following scenarios:
1. after fixing/deleting a course module and revisiting the index page before `core_course\task\course_delete_modules` task can run
2. if the course module to be deleted doesn't have an instance id or an instance id of 0

This is occurring due to the following function:

```php
    /**
     * Get the array of delete_module objects.
     *
     * @return array
     */
    public function get_deletemodules() {
        // Unset if the module is already deleted successfully.
        // This is only required if MDL-80930 is not applied.
        // MDL-80930 is integrated, there should be no "NULL moduleinstanceid".
        foreach ($this->deletemodules as $key => $deletemodule) {
            // No instanceid.
            if (is_null($deletemodule->moduleinstanceid)) {
                unset($this->deletemodules[$key]);
            }
        }
        return $this->deletemodules;
    }
```

This function is used only for backwards compatibility during unit tests, see https://github.com/catalyst/moodle-tool_fix_delete_modules/issues/23#issuecomment-2252151742

>  This is for backward compatibility where MDL-80930 is not applied, that is, to make the unit test work regardless MDL-80930 is applied or not

However, it is still executed during normal use. In the two scenarios, this function is unsetting the object. When we go to access this object, an exception is thrown in the following function:

```php
    private function get_gradestable(delete_task $deletetask) {

        // Skip for multimodule adhoc tasks (too much data to be meaningful!).
        if ($deletetask->is_multi_module_task()) {
            return '';
        }

        global $DB, $OUTPUT;

        $output = '';
        $deletemodule = current($deletetask->get_deletemodules()); // Only one module in the task.

        if ($records = $DB->get_records('grade_items',
                                        array('itemmodule' => $deletemodule->get_modulename(),
                                              'iteminstance' => $deletemodule->moduleinstanceid,
                                              'courseid' => $deletemodule->courseid))) {
```

To resolve this, we add a check if PHPUnit tests are being executed.