### PR TITLE
remove unused attributes

### DIFF
--- a/form.php
+++ b/form.php
@@ -46,10 +46,6 @@ class fix_delete_modules_form extends moodleform {
         // Add elements to form.
         global $CFG;
 
-        $this->actionurl = new \moodle_url('/admin/tool/fix_delete_modules/fix_module.php', array(
-            'sesskey'          => sesskey()
-        ));
-
         $mform = $this->_form; // Don't forget the underscore!
 
         $mform->addElement('submit', 'submit',  get_string('button_delete_mod_without_backup', 'tool_fix_delete_modules')
@@ -84,11 +80,7 @@ class separate_delete_modules_form extends moodleform {
     public function definition() {
         // Add elements to form.
         global $CFG;
-
-        $this->actionurl = new \moodle_url('/admin/tool/fix_delete_modules/separate_module.php', array(
-            'sesskey'          => sesskey()
-        ));
-
+        
         $mform = $this->_form; // Don't forget the underscore!
 
         $mform->addElement('submit', 'submit',  get_string('button_separate_modules', 'tool_fix_delete_modules')


### PR DESCRIPTION
Removing `$this->actionurl` from the forms, its throwing an error in php 8.3 because you can no longer create parameters dynamically.

Both these classes extend `moodleform` class, which ofcourse dosen't have actionurl paramater, or we wouldn't get this error in the first place. The only time action is ever passed through it on `__contruct`, and is never stored anywhere just used, and passed through to `$this->_form` which uses the class `MoodleQuickForm`

`MoodleQuickForm` also never stores action as a variable either, it is just saved to `$this-> _attributes` array, so it is not possible with the code I can see that `$this->actionurl` is doing anything. 

It is possible on older versions of Moodle it has done something, though looking at blame on the relevant classes, this is very very old moodle code so I doubt it. I think it was just an attempt to set action url initially and its stuck around.

We do pass through action as a paramater to the constructor properly anyway, so it does work the proper method