### PR TITLE
Issue #28: Fixed PHPUnit test issues

### DIFF
--- a/classes/reporter.php
+++ b/classes/reporter.php
@@ -136,7 +136,7 @@ class reporter {
      *
      * @return array of diagnosis
      */
-    private function get_diagnosis_data(array $taskids = null) {
+    private function get_diagnosis_data(?array $taskids = null) {
         $diagnoses = array();
         $deletetaskslist = new delete_task_list($this->minimumfaildelay);
         $deletetasks = $deletetaskslist->get_deletetasks();

--- a/classes/surgeon.php
+++ b/classes/surgeon.php
@@ -310,7 +310,13 @@ class surgeon {
         }
 
         // Notify the competency subsystem.
-        \core_competency\api::hook_course_module_deleted($cm);
+        // The function hook_course_module_deleted() deletes the module context in 5.1+.
+        // context_module::instance($cm->id); causes dml_missing_record_exception when the course_modules record is already absent.
+        try {
+            \core_competency\api::hook_course_module_deleted($cm);
+        } catch (\dml_missing_record_exception $e) {
+            // Context no longer exists; competency data already cleaned up or not present.
+        }
 
         // Delete the context.
         if ($modcontext) {


### PR DESCRIPTION
Closes issue #28.

Added `?` to nullable function parameter for `get_diagnosis_data()` to resolve PHPUnit test deprecation warning.

Added try/catch around course competency API call. 

Why does this fails in 5.1, but not 4.5? In Moodle 4.5, the API call to `hook_course_module_deleted()` simply deletes the course module competency record. 

Code in 4.5:
```
 /**
     * Action to perform when a course module is deleted.
     *
     * Do not call this directly, this is reserved for core use.
     *
     * @param stdClass $cm The CM object.
     * @return void
     */
    public static function hook_course_module_deleted(stdClass $cm) {
        global $DB;
        $DB->delete_records(course_module_competency::TABLE, array('cmid' => $cm->id));
    }
```
In 5.1, the `hook_course_module_deleted()` function also deletes the context from the `competency_evidence` table:
```
/**
     * Action to perform when a course module is deleted.
     *
     * Do not call this directly, this is reserved for core use.
     *
     * @param stdClass $cm The CM object.
     * @return void
     */
    public static function hook_course_module_deleted(stdClass $cm) {
        global $DB;
        $DB->delete_records(course_module_competency::TABLE, array('cmid' => $cm->id));
        $context = context_module::instance($cm->id);
        $DB->delete_records(evidence::TABLE, ['contextid' => $context->id]);
    }
```
During the test, the CM context does not exist in the `competency_evidence` table, causing the unit test to fail with a `dml_missing_record_exception`. We avoid the test failure by adding a try/catch block around the API call. If the record does not exist in the `competency_evidence` table, then there is no data to be removed, and the execution will continue.

## Environment
```
- Moodle 5.1.3+ (Build: 20260220)
- PHP: 8.4.22
- DB: MySQL 8.4
- Branch: MOODLE_35_STABLE
```

## Testing instructions:
- `tool_fix_delete_modules` test suite: `vendor/bin/phpunit --testsuite tool_fix_delete_modules_testsuite`
- Running the unit tests for `tool_fix_delete_modules` will produce the following errors (on the above environment):
```
Moodle 5.1.3+ (Build: 20260220)
Php: 8.4.22, mysqli: 8.4.9, OS: Linux 6.17.0-1025-oem x86_64
PHPUnit 11.5.12 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.4.22
Configuration: /var/www/upstream-mdl/phpunit.xml

..............E.........                                          24 / 24 (100%)

Time: 00:17.836, Memory: 101.00 MB

There was 1 error:

1) tool_fix_delete_modules\reporter_test::test_reporter_class
dml_missing_record_exception: Invalid course module ID (SELECT id,course FROM {course_modules} WHERE id = ?
[array (
  0 => 238000,
)])

/var/www/upstream-mdl/public/lib/dml/moodle_database.php:1653
/var/www/upstream-mdl/public/lib/dml/moodle_database.php:1629
/var/www/upstream-mdl/public/lib/classes/context/module.php:262
/var/www/upstream-mdl/public/competency/classes/api.php:4784
/var/www/upstream-mdl/public/admin/tool/fix_delete_modules/classes/surgeon.php:313
/var/www/upstream-mdl/public/admin/tool/fix_delete_modules/classes/surgeon.php:118
/var/www/upstream-mdl/public/admin/tool/fix_delete_modules/classes/surgeon.php:67
/var/www/upstream-mdl/public/admin/tool/fix_delete_modules/classes/reporter.php:189
/var/www/upstream-mdl/public/admin/tool/fix_delete_modules/classes/reporter.php:162
/var/www/upstream-mdl/public/admin/tool/fix_delete_modules/tests/reporter_test.php:135

--

1 test triggered 1 PHP deprecation:

1) /var/www/upstream-mdl/public/admin/tool/fix_delete_modules/classes/reporter.php:139
tool_fix_delete_modules\reporter::get_diagnosis_data(): Implicitly marking parameter $taskids as nullable is deprecated, the explicit nullable type must be used instead

Triggered by:

* tool_fix_delete_modules\reporter_test::test_reporter_class
  /var/www/upstream-mdl/public/admin/tool/fix_delete_modules/tests/reporter_test.php:46

ERRORS!
Tests: 24, Assertions: 392, Errors: 1, Deprecations: 1, PHPUnit Deprecations: 24.
```
### Expected Output from PHPUnit Tests
- Pulling this branch `MOODLE_35_STABLE-issue28` and re-running the testsuite:
```
Moodle 5.1.3+ (Build: 20260220)
Php: 8.4.22, mysqli: 8.4.9, OS: Linux 6.17.0-1025-oem x86_64
PHPUnit 11.5.12 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.4.22
Configuration: /var/www/upstream-mdl/phpunit.xml

........................                                          24 / 24 (100%)

Time: 00:18.759, Memory: 99.00 MB

OK, but there were issues!
Tests: 24, Assertions: 426, PHPUnit Deprecations: 24.
```